### PR TITLE
Fix SSO get profile parameters and update variables to be generic

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -3,10 +3,11 @@ var router = express.Router();
 var express = require('express');
 var router = express.Router();
 const WorkOS = require('@workos-inc/node').default;
+
 const client = new WorkOS(process.env.WORKOS_API_KEY);
-const domain = 'zach.workos.dev';
-const redirectURI = 'https://zach.workos.dev/callback';
-const projectID = 'project_01DG5TGK363GRVXP3ZS40WNGEZ';
+const domain = "$YOUR_DOMAIN";
+const redirectURI = "$YOUR_REDIRECT_URI";
+const projectID = "$YOUR_PROJECT_ID";
 
 /* GET home page. */
 router.get('/', function(req, res, next) {

--- a/routes/index.js
+++ b/routes/index.js
@@ -29,7 +29,6 @@ router.get('/callback', async (req, res) => {
   const profile = await client.sso.getProfile({
     code,
     projectID,
-    redirectURI,
   });
   res.json(profile).send();
 });


### PR DESCRIPTION
This PR:
 - removes the `redirectURI` parameter from the `getProfile` call since it is not a valid option: https://github.com/workos-inc/workos-node/blob/master/src/sso/sso.ts#L46
 - updates the variables for `domain`, `redirectURI` and `projectID` to be generic for the user to fill in.